### PR TITLE
Avoid potentially-fatal warning, make debug noise optional

### DIFF
--- a/lib/Dancer/Plugin/EscapeHTML.pm
+++ b/lib/Dancer/Plugin/EscapeHTML.pm
@@ -129,7 +129,7 @@ hook before_template_render => sub {
         : undef;
 
     my_debug("Before encoding, tokens were:", $tokens);
-    $tokens = _encode($tokens, $config);
+    $tokens = _encode($tokens);
     my_debug("After encoding, tokens were:", $tokens);
 
 };
@@ -139,7 +139,7 @@ hook before_template_render => sub {
 sub _encode {
     my $in = shift;
     return unless defined $in; # avoid interpolation warnings
-    my_debug "_encode called, looking at $in which is a "  .ref $in;
+    my_debug "_encode called, looking at $in which is a " . ref $in;
     if (!ref $in) {
         my_debug "Encoding value $in...";
         $in = HTML::Entities::encode_entities($in);

--- a/lib/Dancer/Plugin/EscapeHTML.pm
+++ b/lib/Dancer/Plugin/EscapeHTML.pm
@@ -71,6 +71,20 @@ register 'unescape_html' => sub {
     return HTML::Entities::decode_entities(@_);
 };
 
+=head1 Optional verbose debug
+
+If you set the plugin variable 'debug' to a true value, you will get a
+lot more noise in your log at the 'debug' level.
+
+=cut
+
+sub my_debug {
+    my $message = shift;
+    my $config = plugin_setting;
+    if ($config->{'debug'}) {
+        debug $message;
+    }
+}
 
 =head1 Automatic HTML encoding
 
@@ -104,13 +118,13 @@ The above would exclude token names ending in C<_html> from being escaped.
 hook before_template_render => sub {
     my $tokens = shift;
     my $config = plugin_setting;
-    debug "Hook fired";
+    my_debug "Hook fired";
     return unless $config->{automatic_escaping};
-    debug "OK, calling _encode";
+    my_debug "OK, calling _encode";
 
-    debug("Before encoding, tokens were:", $tokens);
+    my_debug("Before encoding, tokens were:", $tokens);
     $tokens = _encode($tokens, $config);
-    debug("After encoding, tokens were:", $tokens);
+    my_debug("After encoding, tokens were:", $tokens);
 
 };
 
@@ -118,11 +132,12 @@ hook before_template_render => sub {
 # TODO: this will probably choke on circular references
 sub _encode {
     my ($in,$config) = @_;
-    debug "_encode called, looking at $in which is a "  .ref $in;
+    return unless defined $in; # avoid interpolation warnings
+    my_debug "_encode called, looking at $in which is a "  .ref $in;
     if (!ref $in) {
-        debug "Encoding value $in...";
+        my_debug "Encoding value $in...";
         $in = HTML::Entities::encode_entities($in);
-        debug "Encoded value: $in";
+        my_debug "Encoded value: $in";
     } elsif (ref $in eq 'ARRAY') {
         $in->[$_] = _encode($in->[$_]) for (0..$#$in);
     } elsif (ref $in eq 'HASH') {

--- a/lib/Dancer/Plugin/EscapeHTML.pm
+++ b/lib/Dancer/Plugin/EscapeHTML.pm
@@ -79,10 +79,7 @@ lot more noise in your log at the 'debug' level.
 =cut
 
 sub my_debug {
-    my $config = plugin_setting;
-    if ($config->{debug}) {
-        debug @_;
-    }
+    debug @_ if plugin_setting->{debug};
 }
 
 =head1 Automatic HTML encoding


### PR DESCRIPTION
Hi David,

I have made three changes. They do not cleanly correspond to these commits, sorry!
1. In my development environment, I have
   warnings: 1
   which was making this a fatal error:
   Warning caught during route execution: Use of uninitialized value $in in concatenation (.) or string at /.../lib/perl5/Dancer/Plugin/EscapeHTML.pm line 125.
   so I added this line to _encode:
   return unless defined $in; # avoid interpolation warnings
2. The debugging was excessive, so I made it optional by adding and using a my_debug subroutine which only logs the message if $config->{'debug'} is set. (Fixed in second commit to pass through @_ instead of only the first argument and later to be concise!)
   
   I think it would be better to provide a 'debug' flag as part of Dancer::Plugin so that every plugin's debugging can be toggled in the app config, but I'm not sure how to go about that. Maybe "use base Dancer::Plugin;" which would override debug?
3. The exclude_pattern was being recompiled for every key. That was excessive. Now it's only recompiled (or set to undef) once per template call. Also — I think your code had a bug — you weren't passing $config to recursive _escape calls. (Fixed in 3rd commit — where it is irrelevant!)

Cheers,

Tom
