### PR TITLE
avoid reference loops ; trim stale documentation

### DIFF
--- a/lib/Dancer/Plugin/EscapeHTML.pm
+++ b/lib/Dancer/Plugin/EscapeHTML.pm
@@ -118,23 +118,27 @@ hook before_template_render => sub {
 # Encode values, recursing down into hash/arrayrefs.
 sub _encode {
     my $in = shift;
-    return unless defined $in; # avoid interpolation warnings
-    if (!ref $in) {
-        $in = HTML::Entities::encode_entities($in);
-    } else {
-        next if exists $seen{scalar $in}; # avoid reference loops
-        $seen{scalar $in} = 1;
 
-        if (ref $in eq 'ARRAY') {
-            $in->[$_] = _encode($in->[$_]) for (0..$#$in);
-        } elsif (ref $in eq 'HASH') {
-            while (my($k,$v) = each %$in) {
-                next if defined $exclude_pattern
-                    && $k =~ $exclude_pattern;
-                $in->{$k} = _encode($v);
-            }
+    return unless defined $in; # avoid interpolation warnings
+
+    return HTML::Entities::encode_entities($in)
+        unless ref $in;
+
+    return $in
+        if exists $seen{scalar $in}; # avoid reference loops
+
+    $seen{scalar $in} = 1;
+
+    if (ref $in eq 'ARRAY') {
+        $in->[$_] = _encode($in->[$_]) for (0..$#$in);
+    } elsif (ref $in eq 'HASH') {
+        while (my($k,$v) = each %$in) {
+            next if defined $exclude_pattern
+                && $k =~ $exclude_pattern;
+            $in->{$k} = _encode($v);
         }
     }
+
     return $in;
 }
 

--- a/lib/Dancer/Plugin/EscapeHTML.pm
+++ b/lib/Dancer/Plugin/EscapeHTML.pm
@@ -41,10 +41,6 @@ You can encode specific bits of data yourself using the C<escape_html> and
 C<unescape_html> keywords, or you can enable automatic escaping of all values
 passed to the template.
 
-In a future version, it is likely that this automatic escaping can be bypassed
-for certain values - probably by providing parameter names/patterns in the
-configuration to indicate parameters which should be left alone.
-
 
 =head1 KEYWORDS
 
@@ -101,6 +97,7 @@ The above would exclude token names ending in C<_html> from being escaped.
 =cut
 
 my $exclude_pattern;
+my %seen;
 
 hook before_template_render => sub {
     my $tokens = shift;
@@ -112,23 +109,30 @@ hook before_template_render => sub {
         ? qr/$config->{exclude_pattern}/
         : undef;
 
+    # flush seen cache
+    %seen = ();
+
     $tokens = _encode($tokens);
 };
 
 # Encode values, recursing down into hash/arrayrefs.
-# TODO: this will probably choke on circular references
 sub _encode {
     my $in = shift;
     return unless defined $in; # avoid interpolation warnings
     if (!ref $in) {
         $in = HTML::Entities::encode_entities($in);
-    } elsif (ref $in eq 'ARRAY') {
-        $in->[$_] = _encode($in->[$_]) for (0..$#$in);
-    } elsif (ref $in eq 'HASH') {
-        while (my($k,$v) = each %$in) {
-            next if defined $exclude_pattern
-                && $k =~ $exclude_pattern;
-            $in->{$k} = _encode($v);
+    } else {
+        next if exists $seen{scalar $in}; # avoid reference loops
+        $seen{scalar $in} = 1;
+
+        if (ref $in eq 'ARRAY') {
+            $in->[$_] = _encode($in->[$_]) for (0..$#$in);
+        } elsif (ref $in eq 'HASH') {
+            while (my($k,$v) = each %$in) {
+                next if defined $exclude_pattern
+                    && $k =~ $exclude_pattern;
+                $in->{$k} = _encode($v);
+            }
         }
     }
     return $in;
@@ -149,7 +153,7 @@ David Precious, C<< <davidp at preshweb.co.uk> >>
 
 =head1 ACKNOWLEDGEMENTS
 
-Tom Rathborne (trathborne)
+Tom Rathborne C<< <tom.rathborne at gmail.com> >>
 
 
 =head1 LICENSE AND COPYRIGHT


### PR DESCRIPTION
May as well sort out that TODO, no?

I think it's a little faster, too! In the scalar case, 'return entities($in)' is faster than '$in = entities($in) ... return $in'.
